### PR TITLE
Remove "liked" class from modal heart when modal is closed

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -387,6 +387,7 @@ var initForce = function() {
          var close = document.getElementsByClassName("close")[0];
          close.onclick = function(){
           $('.modal, .memoryText, .close, .modal-content__content').removeClass('show');
+          $('.modal-content__heart').removeClass('liked');
          }
 
 


### PR DESCRIPTION
(Only while all modals have the same content, so that prototype user can click into a new modal and the heart is default grey colour and size)
Relates #10 #68 #78